### PR TITLE
Re-useable Vue Components

### DIFF
--- a/app/javascript/components/counter.vue
+++ b/app/javascript/components/counter.vue
@@ -1,6 +1,6 @@
 <template>
   <small v-cloak class="label label-rounded label-secondary" :class="style">
-    {{ value | count }}
+    {{ pretty }}
   </small>
 </template>
 
@@ -19,18 +19,17 @@ export default {
       default: "230"
     }
   },
-  filters: {
-    count: function (value) {
-      if (!value) return '0'
-      value = value.toString()
-      return value.length
-    }
-  },
   computed: {
+    count: function() {
+      return this.value ? this.value.length : '0'
+    },
+    pretty: function() {
+      return (this.count > parseInt(this.max)) ? `${this.max}+${(this.count - this.max)}` : this.count
+    },
     style: function () {
       return {
-        'label-warning': this.value.length > parseInt(this.warning),
-        'label-error': this.value.length > parseInt(this.max)
+        'label-warning': this.count > parseInt(this.high),
+        'label-error': this.count > parseInt(this.max)
       }
     }
   }

--- a/app/javascript/components/counter.vue
+++ b/app/javascript/components/counter.vue
@@ -1,0 +1,38 @@
+<template>
+  <small v-cloak class="label label-rounded label-secondary" :class="style">
+    {{ value | count }}
+  </small>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: String
+    },
+    max: {
+      type: String,
+      default: "250"
+    },
+    high: {
+      type: String,
+      default: "230"
+    }
+  },
+  filters: {
+    count: function (value) {
+      if (!value) return '0'
+      value = value.toString()
+      return value.length
+    }
+  },
+  computed: {
+    style: function () {
+      return {
+        'label-warning': this.value.length > parseInt(this.warning),
+        'label-error': this.value.length > parseInt(this.max)
+      }
+    }
+  }
+}
+</script>

--- a/app/javascript/packs/customers.js
+++ b/app/javascript/packs/customers.js
@@ -1,6 +1,8 @@
 import Vue from 'vue/dist/vue.esm'
 import VueDataScooper from 'vue-data-scooper'
 
+import VueCounter from '../components/counter'
+
 Vue.config.productionTip = false
 Vue.use(VueDataScooper)
 
@@ -10,9 +12,8 @@ document.addEventListener("DOMContentLoaded", () => {
     data: {
       open: true
     },
-    computed: {
-      customerNameLength: function() { return this.customer.name.length },
-      customerRemarksLength: function() { return this.customer.remarks.length },
+    components: {
+      VueCounter
     }
   })
 });

--- a/app/views/customers/_fields.html.erb
+++ b/app/views/customers/_fields.html.erb
@@ -1,8 +1,9 @@
 <div class="form-group">
   <%= f.label :name, class: "form-label" do %>
-    Name <small v-cloak class="label label-rounded label-secondary" :class="{ 'label-warning': customerNameLength > 30, 'label-error': customerNameLength > 40 }">{{ customerNameLength }}</small>
+    Name <vue-counter v-model="customer.name" high="30" max="40"></vue-counter>
   <% end %>
   <%= f.text_field :name, class: "form-input" %>
+  <vue-counter v-bind:value="customer.name" max="50"></vue-counter>
 </div>
 
 <div class="form-group">
@@ -62,7 +63,7 @@
 
 <div class="form-group">
   <%= f.label :remarks, class: "form-label" do %>
-    Remarks <small v-cloak class="label label-rounded label-secondary">{{ customerRemarksLength }}</small>
+    Remarks <vue-counter v-model="customer.remarks"></vue-counter>
   <% end %>
   <%= f.text_area :remarks, class: "form-input" %>
 </div>
@@ -74,12 +75,10 @@
 
 <div v-cloak class="form-group">
   <pre v-if="open" class="code" data-lang="Vuejs data"><code>customer.name = "{{customer.name}}"
-customerNameLength = {{customerNameLength}}
 customer.plan = "{{customer.plan}}"
 customer.gender = {{customer.gender}}
 customer.phones_attributes = {{customer.phones_attributes}}
 customer.confirmed = {{customer.confirmed}}
 customer.approved = {{customer.approved}}
-customer.remarks = "{{customer.remarks}}"
-customerRemarksLength = {{customerRemarksLength}}</code></pre>
+customer.remarks = "{{customer.remarks}}"</code></pre>
 </div>


### PR DESCRIPTION
Hey @kuroda 👋

I've wanted to improve the reusability and moved the functionality inside a vue component. The ecosystem is getting bigger and bigger and this could open a wider range of useful user experience of interactive form components eg. password strength meter, input counter, preview
On the way I've discovered some unexpected behavior.

If the vue component with `v-model` is placed **after** the input field with`v-model="customer.name"` the page brakes or it comes to different broken behavior on `/new` / `/edit`.

```erb
<!-- 💥 breaks -->
<%= f.text_field :name, class: "form-input" %>
<vue-counter v-model="customer.name" high="30" max="40"></vue-counter>

<!-- 🍀 luckily works -->
<vue-counter v-model="customer.name" high="30" max="40"></vue-counter>
<%= f.text_field :name, class: "form-input" %>
```

As the Vue.js docs show, how [`v-model` works on Components](https://vuejs.org/v2/guide/components.html#Using-v-model-on-Components) `v-bind:value` could be a workaround for components arranged **after** the input.

```erb
<!-- 😕 workaround -->
<%= f.text_field :name, class: "form-input" %>
<vue-counter v-bind:value="customer.name" max="50"></vue-counter>
```

It's ok for now, but I wanted to have reusable components a designer without coding knowledge could arrange around the form without checking the order of the fields.
The workaround is ok-ish, but I've lost quite some time to get behind the problem.
Guess it's how [`vue-data-scooper`](https://github.com/kuroda/vue-data-scooper#how-this-plugin-works) iterate over elements with `"v-model"`-attributes. And in my scenario if the component has no `value` it overrides the previous captured data.

🤔 Would it be possible to let `vue-data-scooper` skip the elements with `"v-model"` but without a valid `value` attribute? Your expertise and feedback is highly appreciated 🤓✌️ What do you think?

##### 🐒 patch

I've managed to identify the area and apply an silly monkey-patch that solves the issue.

```diff
-   set(obj, path, el.value)
+   if ( typeof el.value !== 'undefined' ) {
+     set(obj, path, el.value)
+   }
```
👨‍💻 [`src/vue-data-scooper.js#L41`](https://github.com/kuroda/vue-data-scooper/blob/7a2ed27bb96c2714c51b4f3d3ba705dfb6da981e/src/vue-data-scooper.js#L41)

- - -

* reuse `vue-counter` component
* remove custom computed `customer*Length` elements